### PR TITLE
jdk9+ compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 target
 src/test/java/io/*
 src/test/java/org/apache/cxf*
+*.project
+*.classpath
+*.settings

--- a/geronimo-openapi-impl/pom.xml
+++ b/geronimo-openapi-impl/pom.xml
@@ -83,6 +83,12 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.activation</groupId>
+      <artifactId>javax.activation-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
     </dependency>

--- a/geronimo-openapi-impl/pom.xml
+++ b/geronimo-openapi-impl/pom.xml
@@ -73,6 +73,7 @@
       <artifactId>cxf-integration-cdi</artifactId>
     </dependency>
     <!-- not that consistent with microprofile so don't enforce it -->
+    
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
@@ -85,7 +86,6 @@
     <dependency>
       <groupId>javax.activation</groupId>
       <artifactId>javax.activation-api</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/geronimo-openapi-impl/pom.xml
+++ b/geronimo-openapi-impl/pom.xml
@@ -126,7 +126,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.22.0</version>
         <configuration>
           <trimStackTrace>false</trimStackTrace>
           <dependenciesToScan>
@@ -137,7 +136,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>3.0.2</version>
         <configuration>
           <archive combine.children="append">
             <manifestEntries>

--- a/geronimo-openapi-impl/pom.xml
+++ b/geronimo-openapi-impl/pom.xml
@@ -73,7 +73,6 @@
       <artifactId>cxf-integration-cdi</artifactId>
     </dependency>
     <!-- not that consistent with microprofile so don't enforce it -->
-    
     <dependency>
       <groupId>com.fasterxml.jackson.dataformat</groupId>
       <artifactId>jackson-dataformat-yaml</artifactId>
@@ -82,7 +81,7 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
     </dependency>
-
+ 
     <dependency>
       <groupId>javax.activation</groupId>
       <artifactId>javax.activation-api</artifactId>

--- a/geronimo-openapi-maven-plugin/pom.xml
+++ b/geronimo-openapi-maven-plugin/pom.xml
@@ -114,7 +114,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.5</version>
         <executions>
           <execution>
             <id>mojo-descriptor</id>

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
       <dependency>
         <groupId>org.apache.meecrowave</groupId>
         <artifactId>meecrowave-arquillian</artifactId>
-        <version>1.2.1</version>
+        <version>1.2.3</version>
         <scope>test</scope>
         <exclusions>
           <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -249,7 +249,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.7.0</version>
         <configuration>
           <source>1.8</source>
           <target>1.8</target>

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
     <arquillian.version>1.1.14.Final</arquillian.version>
     <testng.version>6.9.9</testng.version>
     <jackson.version>2.9.4</jackson.version>
+    <javax.activation.version>1.2.0</javax.activation.version>
   </properties>
 
   <dependencyManagement>
@@ -167,6 +168,13 @@
         <version>${jackson.version}</version>
         <scope>provided</scope>
         <optional>true</optional>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.activation</groupId>
+        <artifactId>javax.activation-api</artifactId>
+        <version>${javax.activation.version}</version>
+        <scope>runtime</scope>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
       <dependency>
         <groupId>org.apache.cxf</groupId>
         <artifactId>cxf-integration-cdi</artifactId>
-        <version>3.2.4</version>
+        <version>3.2.5</version>
         <scope>provided</scope>
         <optional>true</optional>
         <exclusions>


### PR DESCRIPTION
Enabled java 9+ compilation (with the introduction of activation api at runtime scope).
Removed already defined maven plugin versions (some was outdated).
Updated cxf-integration-cdi to the latest minor release.
Updated gitignore for Eclipse IDE users.