### PR TITLE
fix for the empty ref attribute of RequestBody annotation

### DIFF
--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/model/RequestBodyImpl.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/model/RequestBodyImpl.java
@@ -94,7 +94,9 @@ public class RequestBodyImpl implements RequestBody {
     @Override
     @JsonbProperty("$ref")
     public void setRef(final String _ref) {
-        this._ref = _ref.startsWith("#") ? _ref : ("#/components/requestBodies/" + _ref);
+        if (!_ref.isEmpty()) {
+          this._ref = _ref.startsWith("#") ? _ref : ("#/components/requestBodies/" + _ref);
+        }
     }
 
     @Override


### PR DESCRIPTION
When a jax-rs method parameter is annotated in this way, without the ref attribute:

```
  public AssetViewModel create(@RequestBody(
                                            name = "asset",
                                            description = "request body in json format",
                                            content = @Content(
                                                               mediaType = APPLICATION_JSON,
                                                               schema = @Schema(name = "Asset", 
                                                                                                  implementation = AssetViewModel.class)),
                                                               required = true) final AssetViewModel _asset) {

    _log.log(Level.INFO, "Creating {0}", _asset);

    return _asset;
  }
```

this code:
`this._ref = _ref.startsWith("#") ? _ref : ("#/components/requestBodies/" + _ref);` generates an invalid openapi json:

```
"/api/asset":{
      "post":{
        "deprecated":false,
        "description":"api to create a new Asset",
        "operationId":"create",
        "parameters":[
        ],
        "requestBody":{
          "$ref":"#/components/requestBodies/",
```
I think that isn't correct, and swagger-ui complains with the error:

> Resolver error at paths./api/asset.post.requestBody.$ref
> Could not resolve reference because of: Could not resolve pointer: /components/requestBodies/ does not exist in document

