### PR TITLE
GERONIMO-6687 use default parameter style instead of hardcoding simple

### DIFF
--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
@@ -446,16 +446,20 @@ public class AnnotationProcessor {
                         final ParameterImpl parameter = new ParameterImpl();
                         if (annotatedElement.isAnnotationPresent(HeaderParam.class)) {
                             parameter.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.HEADER)
+                                    .style(org.eclipse.microprofile.openapi.models.parameters.Parameter.Style.SIMPLE)
                                     .name(annotatedElement.getAnnotation(HeaderParam.class).value());
                         } else if (annotatedElement.isAnnotationPresent(CookieParam.class)) {
                             parameter.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.COOKIE)
+                                    .style(org.eclipse.microprofile.openapi.models.parameters.Parameter.Style.FORM)
                                     .name(annotatedElement.getAnnotation(CookieParam.class).value());
                         } else if (annotatedElement.isAnnotationPresent(PathParam.class)) {
                             parameter.required(true)
                                     .in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.PATH)
+                                    .style(org.eclipse.microprofile.openapi.models.parameters.Parameter.Style.SIMPLE)
                                     .name(annotatedElement.getAnnotation(PathParam.class).value());
                         } else if (annotatedElement.isAnnotationPresent(QueryParam.class)) {
                             parameter.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.QUERY)
+                                    .style(org.eclipse.microprofile.openapi.models.parameters.Parameter.Style.FORM)
                                     .name(annotatedElement.getAnnotation(QueryParam.class).value());
                         }
                         parameter.schema(schemaProcessor.mapSchemaFromClass(

--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
@@ -459,8 +459,7 @@ public class AnnotationProcessor {
                                     .name(annotatedElement.getAnnotation(QueryParam.class).value());
                         }
                         parameter.schema(schemaProcessor.mapSchemaFromClass(
-                                    () -> getOrCreateComponents(openAPI), annotatedElement.getType()))
-                                 .style(org.eclipse.microprofile.openapi.models.parameters.Parameter.Style.SIMPLE);
+                                    () -> getOrCreateComponents(openAPI), annotatedElement.getType()));
                         return parameter;
                     }
                     return null;


### PR DESCRIPTION
I've removed the hardcoded simple style, see example here: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#parameter-object-examples