### PR TITLE
The AnnotationProcessor should be able to deduct the parameter name from JAX-RS annotations

### DIFF
--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
@@ -59,7 +59,6 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
-import org.apache.cxf.common.util.StringUtils;
 import org.apache.geronimo.microprofile.openapi.config.GeronimoOpenAPIConfig;
 import org.apache.geronimo.microprofile.openapi.impl.model.APIResponseImpl;
 import org.apache.geronimo.microprofile.openapi.impl.model.APIResponsesImpl;
@@ -903,7 +902,7 @@ public class AnnotationProcessor {
     }
 
     private void mapParameterName(final ParameterImpl impl, final String name) {
-        if (StringUtils.isEmpty(impl.getName()) && !StringUtils.isEmpty(name)) {
+        if (impl.getName() == null || impl.getName().isEmpty()) {
             impl.name(name);
         }
     }

--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
@@ -59,6 +59,7 @@ import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 
+import org.apache.cxf.common.util.StringUtils;
 import org.apache.geronimo.microprofile.openapi.config.GeronimoOpenAPIConfig;
 import org.apache.geronimo.microprofile.openapi.impl.model.APIResponseImpl;
 import org.apache.geronimo.microprofile.openapi.impl.model.APIResponsesImpl;
@@ -881,16 +882,30 @@ public class AnnotationProcessor {
         }
         if (annotatedElement != null) {
             if (annotatedElement.isAnnotationPresent(HeaderParam.class)) {
+                final HeaderParam annotation = annotatedElement.getAnnotation(HeaderParam.class);
                 impl.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.HEADER);
+                mapParameterName(impl, annotation.value());
             } else if (annotatedElement.isAnnotationPresent(CookieParam.class)) {
+                final CookieParam annotation = annotatedElement.getAnnotation(CookieParam.class);
                 impl.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.COOKIE);
+                mapParameterName(impl, annotation.value());
             } else if (annotatedElement.isAnnotationPresent(PathParam.class)) {
+                final PathParam annotation = annotatedElement.getAnnotation(PathParam.class);
                 impl.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.PATH);
+                mapParameterName(impl, annotation.value());
             } else if (annotatedElement.isAnnotationPresent(QueryParam.class)) {
+                final QueryParam annotation = annotatedElement.getAnnotation(QueryParam.class);
                 impl.in(org.eclipse.microprofile.openapi.models.parameters.Parameter.In.QUERY);
+                mapParameterName(impl, annotation.value());
             }
         }
         return impl;
+    }
+
+    private void mapParameterName(final ParameterImpl impl, final String name) {
+        if (StringUtils.isEmpty(impl.getName()) && !StringUtils.isEmpty(name)) {
+            impl.name(name);
+        }
     }
 
     private Example mapExample(final ExampleObject exampleObject) {

--- a/geronimo-openapi-impl/src/test/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessorTest.java
+++ b/geronimo-openapi-impl/src/test/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessorTest.java
@@ -31,6 +31,7 @@ import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 
 import java.util.HashMap;
@@ -53,7 +54,21 @@ public class AnnotationProcessorTest {
         assertNotNull(pathItem);
         List<Parameter> parameters = pathItem.getGET().getParameters();
         assertEquals(Parameter.In.PATH, parameters.get(0).getIn());
+        assertEquals("a", parameters.get(0).getName());
         // TODO add more assertions
+    }
+    
+    @Test
+    public void ensureParameterAnnotationsAreMerged() {
+        AnnotationProcessor annotationProcessor = new AnnotationProcessor(GeronimoOpenAPIConfig.create(), new NamingStrategy.Default());
+        OpenAPI openAPI = new OpenAPIImpl();
+        annotationProcessor.processClass("", openAPI, new ClassElement(TestResource.class),
+                Stream.of(TestResource.class.getMethods()).map(MethodElement::new));
+        PathItem pathItem = openAPI.getPaths().get("/test/bye");
+        assertNotNull(pathItem);
+        List<Parameter> parameters = pathItem.getGET().getParameters();
+        assertEquals(Parameter.In.QUERY, parameters.get(0).getIn());
+        assertEquals("b", parameters.get(0).getName());
     }
 
     @Test
@@ -123,6 +138,12 @@ public class AnnotationProcessorTest {
         @Produces(MediaType.TEXT_PLAIN)
         public String hello(@PathParam("a") String a) {
             return "hello";
+        }
+        
+        @GET
+        @Path("/bye")
+        @Produces(MediaType.TEXT_PLAIN)
+        public void bye(@org.eclipse.microprofile.openapi.annotations.parameters.Parameter(required = true) @QueryParam("b") String b) {
         }
     }
 }


### PR DESCRIPTION
The Issue
---
Often the `@Parameter` annotation is used to augment the JAX-RS annotations with the missing metadata (for example, if the paremeter `required` or not). In this case the `name` attribute of the  `@Parameter`  could be omitted and taken from the JAX-RS counterpart, for example:

```
@DELETE
public void delete(@Parameter(required = true) @PathParam("id") String id) {
    ...
}
```
But at the moment, the `AnnotationProcessor` always use the name from `@Parameter` (if the annotation is present) and it leads to necessary duplication of the same metadata in both places. This small PR addresses that.

@rmannibucau could you please take a look? Thanks!