### PR TITLE
The AnnotationProcessor should inject media type instead of response code (when endpoint returns void or Response)

### DIFF
--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
@@ -320,12 +320,11 @@ public class AnnotationProcessor {
                          if (returnType == void.class || returnType == Response.class) {
                              if (v.getContent() == null || v.getContent().isEmpty()) {
                                  final ContentImpl content = new ContentImpl();
-                                 if (Response.class == returnType ||
-                                         Stream.of(m.getParameters()).anyMatch(it -> it.isAnnotationPresent(Suspended.class))) {
-                                     content.put("200", new MediaTypeImpl());
-                                 } else {
-                                     content.put("204", new MediaTypeImpl());
-                                 }
+
+                                 produces
+                                     .orElseGet(() -> singletonList("*/*"))
+                                     .forEach(mt -> content.put(mt, new MediaTypeImpl()));
+                                 
                                  v.content(content);
                              }
                              return;

--- a/geronimo-openapi-impl/src/test/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessorTest.java
+++ b/geronimo-openapi-impl/src/test/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessorTest.java
@@ -21,11 +21,15 @@ import org.apache.geronimo.microprofile.openapi.impl.model.OpenAPIImpl;
 import org.apache.geronimo.microprofile.openapi.impl.processor.reflect.ClassElement;
 import org.apache.geronimo.microprofile.openapi.impl.processor.reflect.MethodElement;
 import org.apache.geronimo.microprofile.openapi.impl.processor.spi.NamingStrategy;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
 import org.eclipse.microprofile.openapi.models.PathItem;
 import org.eclipse.microprofile.openapi.models.parameters.Parameter;
+import org.eclipse.microprofile.openapi.models.responses.APIResponses;
 import org.testng.annotations.Test;
 
+import javax.json.JsonPatch;
+import javax.ws.rs.DELETE;
 import javax.ws.rs.GET;
 import javax.ws.rs.PATCH;
 import javax.ws.rs.Path;
@@ -33,6 +37,7 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 import java.util.HashMap;
 import java.util.List;
@@ -69,6 +74,52 @@ public class AnnotationProcessorTest {
         List<Parameter> parameters = pathItem.getGET().getParameters();
         assertEquals(Parameter.In.QUERY, parameters.get(0).getIn());
         assertEquals("b", parameters.get(0).getName());
+    }
+    
+    @Test
+    public void ensureResponsesMediaTypeIsSetForDefaultResponses() {
+        AnnotationProcessor annotationProcessor = new AnnotationProcessor(GeronimoOpenAPIConfig.create(), new NamingStrategy.Default());
+        OpenAPI openAPI = new OpenAPIImpl();
+        annotationProcessor.processClass("", openAPI, new ClassElement(TestResource.class),
+                Stream.of(TestResource.class.getMethods()).map(MethodElement::new));
+        PathItem pathItem = openAPI.getPaths().get("/test/bye");
+        assertNotNull(pathItem);
+        APIResponses responses = pathItem.getGET().getResponses();
+        assertEquals(responses.size(), 2);
+        assertNotNull(responses.get("default"));
+        assertNotNull(responses.get("default").getContent().get("text/plain"));
+        assertNotNull(responses.get("204"));
+        assertNotNull(responses.get("204").getContent().get("text/plain"));
+    }
+    
+    @Test
+    public void ensureResponsesMediaTypeIsSetForAllResponses() {
+        AnnotationProcessor annotationProcessor = new AnnotationProcessor(GeronimoOpenAPIConfig.create(), new NamingStrategy.Default());
+        OpenAPI openAPI = new OpenAPIImpl();
+        annotationProcessor.processClass("", openAPI, new ClassElement(TestResource.class),
+                Stream.of(TestResource.class.getMethods()).map(MethodElement::new));
+        PathItem pathItem = openAPI.getPaths().get("/test/bye");
+        assertNotNull(pathItem);
+        APIResponses responses = pathItem.getPATCH().getResponses();
+        assertEquals(responses.size(), 2);
+        assertNotNull(responses.get("404"));
+        assertNotNull(responses.get("404").getContent().get("application/json"));
+        assertNotNull(responses.get("204"));
+        assertNotNull(responses.get("204").getContent().get("application/json"));
+    }
+    
+    @Test
+    public void ensureResponsesDefaultMediaTypeIsSet() {
+        AnnotationProcessor annotationProcessor = new AnnotationProcessor(GeronimoOpenAPIConfig.create(), new NamingStrategy.Default());
+        OpenAPI openAPI = new OpenAPIImpl();
+        annotationProcessor.processClass("", openAPI, new ClassElement(TestResource.class),
+                Stream.of(TestResource.class.getMethods()).map(MethodElement::new));
+        PathItem pathItem = openAPI.getPaths().get("/test/bye");
+        assertNotNull(pathItem);
+        APIResponses responses = pathItem.getDELETE().getResponses();
+        assertEquals(responses.size(), 1);
+        assertNotNull(responses.get("204"));
+        assertNotNull(responses.get("204").getContent().get("*/*"));
     }
 
     @Test
@@ -144,6 +195,21 @@ public class AnnotationProcessorTest {
         @Path("/bye")
         @Produces(MediaType.TEXT_PLAIN)
         public void bye(@org.eclipse.microprofile.openapi.annotations.parameters.Parameter(required = true) @QueryParam("b") String b) {
+        }
+        
+        @DELETE
+        @Path("/bye")
+        @APIResponse(responseCode = "204")
+        public void bye() {
+        }
+        
+        @PATCH
+        @Path("/bye")
+        @Produces(MediaType.APPLICATION_JSON)
+        @APIResponse(responseCode = "204")
+        @APIResponse(responseCode = "404")
+        public Response bye(JsonPatch patch) {
+            return Response.ok().build();
         }
     }
 }


### PR DESCRIPTION
The Problem
----
Under certain conditions, for example when endpoint returns `void` or generic `Response`, the `AnnotationProcessor` does not properly inject the media type (which could be omitted or explicitly provided using `@Produces` JAX-RS annotation). Here is an example (using Swagger UI here as it is easier to spot the issue visually, the underlying JSON / YAML spec has the same data):

![before](https://user-images.githubusercontent.com/509855/56208381-02477180-601f-11e9-9c84-c402f835c464.png)

Whereas the expected media type should be compatible with https://tools.ietf.org/html/rfc6838 (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#mediaTypes). The expected behavior is to set media type to `*/*` (if not provided):

![after](https://user-images.githubusercontent.com/509855/56208657-a4fff000-601f-11e9-8346-78c35468ca83.png)

Or pick the value from `@Produces` annotation, which this PR is about.
Tracker: https://issues.apache.org/jira/browse/GERONIMO-6722

@rmannibucau mind please taking a look? Thanks!

