### PR TITLE
Always use reusable object component

### DIFF
--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/impl/processor/AnnotationProcessor.java
@@ -564,12 +564,14 @@ public class AnnotationProcessor {
         api.components(impl);
         processCallbacks(api, components.callbacks());
         if (components.schemas().length > 0) {
-            impl.schemas(Stream.of(components.schemas())
-                               .map(it -> {
-                                   final String ref = of(it.name()).filter(n -> !n.isEmpty()).orElseGet(() -> it.ref());
-                                   return new SchemaWithRef(ref, mapSchema(api, it, ref));
-                               })
-                               .collect(toMap(it -> it.ref, it -> it.schema)));
+            Map<String, org.eclipse.microprofile.openapi.models.media.Schema> schemas = Stream.of(components.schemas())
+                .map(it -> {
+                    final String ref = of(it.name()).filter(n -> !n.isEmpty()).orElseGet(() -> it.ref());
+                    return new SchemaWithRef(ref, mapSchema(api, it, ref));
+                })
+                .collect(toMap(it -> it.ref, it -> it.schema));
+
+            schemas.forEach((key, value) -> impl.getSchemas().putIfAbsent(key,value));
         }
         if (components.links().length > 0) {
             impl.links(Stream.of(components.links()).collect(


### PR DESCRIPTION
Hi everyone,

currently geronimo uses a schema ref in the components section only starting from the second usage. The first time the object schema is added to the components but also embedded at the calling point.
This behavior leads to two different classes, if someone uses the openapi.json to generate classes.

For better understanding, i've provided a openapi.json generated before and after the patch.
Irrelevant parts are removed to keep it small.

Current version:
```{
  "components":{
    "schemas":{
      "hello_Greeting":{
        "description":"Bla",
        "properties":{
          "id":{
            "description":"an id",
            "type":"integer"
          },
          "content":{
            "description":"Content",
            "type":"string"
          }
        },
        "required":[
          "id",
          "content"
        ],
        "title":"Greeting",
        "type":"object"
      }
    }
  },
  "paths":{
    "/greeting":{
      "get":{
        ...
        "responses":{
          "200":{
            "content":{
              "application/json":{
                "schema":{
                  "description":"Bla",
                  "properties":{
                    "id":{
                      "description":"an id",
                      "type":"integer"
                    },
                    "content":{
                      "description":"Content",
                      "type":"string"
                    }
                  },
                  "required":[
                    "id",
                    "content"
                  ],
                  "title":"Greeting",
                  "type":"object"
                }
              }
            }
          }
        }
      }
    },
    "/test":{
      "get":{
        ...
        "responses":{
          "200":{
            "content":{
              "application/json":{
                "schema":{
                  "$ref":"#/components/schemas/hello_Greeting",
                  "type":"object"
                }
              }
            }
          }
        }
      }
    }
  }
}
```

With my fix:
```
{
  "components":{
    "schemas":{
      "Greeting":{
        "description":"Bla",
        "properties":{
          "id":{
            "description":"an id",
            "type":"integer"
          },
          "content":{
            "description":"Content",
            "type":"string"
          }
        },
        "required":[
          "id",
          "content"
        ],
        "title":"Greeting",
        "type":"object"
      }
    }
  },
  "paths":{
    "/greeting":{
      "get":{
        ...
        "responses":{
          "200":{
            "content":{
              "application/json":{
                "schema":{
                  "$ref":"#/components/schemas/Greeting",
                  "type":"object"
                }
              }
            }
          }
        }
      }
    },
    "/test":{
      "get":{
        ...
        "responses":{
          "200":{
            "content":{
              "application/json":{
                "schema":{
                  "$ref":"#/components/schemas/Greeting",
                  "type":"object"
                }
              }
            }
          }
        }
      }
    }
  }
}
```

The difference is at the path "/greeting". The current version will embed the schema and use the ref from the second time on. However the fix will refer to the schema in the components already on the first time.

In addition I have added, that if no providedRef is set and the schema.name attribute is set, it will be used as providedRef.

Feel free to contact me, if you have questions or change something in my fix.

Cheers,
Robert
