### PR TITLE
Skip @RegisterRestClient

### DIFF
--- a/geronimo-openapi-impl/pom.xml
+++ b/geronimo-openapi-impl/pom.xml
@@ -107,6 +107,17 @@
       <artifactId>geronimo-config-impl</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.eclipse.microprofile.rest.client</groupId>
+      <artifactId>microprofile-rest-client-api</artifactId>
+      <version>1.3.3</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-mp-client</artifactId>
+      <version>3.3.3</version>
+    </dependency>
+    <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-all</artifactId>
     </dependency>

--- a/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/cdi/GeronimoOpenAPIExtension.java
+++ b/geronimo-openapi-impl/src/main/java/org/apache/geronimo/microprofile/openapi/cdi/GeronimoOpenAPIExtension.java
@@ -61,6 +61,7 @@ import org.eclipse.microprofile.openapi.OASConfig;
 import org.eclipse.microprofile.openapi.OASFilter;
 import org.eclipse.microprofile.openapi.OASModelReader;
 import org.eclipse.microprofile.openapi.models.OpenAPI;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
 public class GeronimoOpenAPIExtension implements Extension {
 
@@ -123,6 +124,7 @@ public class GeronimoOpenAPIExtension implements Extension {
     <T> void findEndpointsAndApplication(@Observes final ProcessBean<T> event) {
         final String typeName = event.getAnnotated().getBaseType().getTypeName();
         if (classes == null && !skipScan && event.getAnnotated().isAnnotationPresent(Path.class) &&
+                !event.getAnnotated().isAnnotationPresent(RegisterRestClient.class) &&
                 !typeName.startsWith("org.apache.geronimo.microprofile.openapi.") &&
                 (packages == null || packages.stream().anyMatch(typeName::startsWith))) {
             endpoints.add(event.getBean());


### PR DESCRIPTION
When an implementation of MicroProfile REST client is available on the classpath, the AirlinesAppTest TCK test fails, as the `org.eclipse.microprofile.openapi.apps.airlines.resources.PlayerService` bean is incorrectly included in the set of endpoints.

Test failure details:

```
[ERROR] Failures: 
[ERROR] org.eclipse.microprofile.openapi.tck.AirlinesAppTest.testRestClientNotPickedUp(org.eclipse.microprofile.openapi.tck.AirlinesAppTest)
[ERROR]   Run 1: AirlinesAppTest>Arquillian.run:138->testRestClientNotPickedUp:191 1 expectation failed.
JSON path paths.'/player/{playerId}' doesn't match.
Expected: null
  Actual: {get={operationId=getPlayerById, responses={200={description=default response, content={application/json={schema={type=string}}}}, default={description=default response, content={application/json={schema={type=string}}}}}, parameters=[{schema={type=string}, in=path, name=playerId, style=simple, required=true}]}}

[ERROR]   Run 2: AirlinesAppTest>Arquillian.run:138->testRestClientNotPickedUp:191 1 expectation failed.
JSON path paths.'/player/{playerId}' doesn't match.
Expected: null
  Actual: {get={operationId=getPlayerById, responses={200={description=default response, content={application/json={schema={type=string}}}}, default={description=default response, content={application/json={schema={type=string}}}}}, parameters=[{schema={type=string}, in=path, name=playerId, style=simple, required=true}]}}

```